### PR TITLE
Add configurable local care image and settings button

### DIFF
--- a/db_dialog.py
+++ b/db_dialog.py
@@ -1,6 +1,8 @@
 from PyQt5 import QtWidgets
 
 class DBConfigDialog(QtWidgets.QDialog):
+    """Dialog used for configuring MySQL connection parameters."""
+
     def __init__(self, parent=None, current_config=None):
         super().__init__(parent)
         self.setWindowTitle("Настройки подключения к БД")

--- a/label_settings.py
+++ b/label_settings.py
@@ -2,6 +2,8 @@ from PyQt5 import QtWidgets
 import os
 
 class LabelSettingsDialog(QtWidgets.QDialog):
+    """Dialog window for editing PDF label parameters."""
+
     def __init__(self, parent=None, current_settings=None):
         super().__init__(parent)
         self.setWindowTitle("Настройки этикетки")
@@ -27,7 +29,7 @@ class LabelSettingsDialog(QtWidgets.QDialog):
 
         self.output_file = QtWidgets.QLineEdit(current_settings.get("output_file", "labels.pdf"))
 
-        self.care_image_input = QtWidgets.QLineEdit(current_settings.get("care_image_url", ""))
+        self.care_image_input = QtWidgets.QLineEdit(current_settings.get("care_image_path", ""))
         self.browse_button = QtWidgets.QPushButton("📁")
         self.browse_button.clicked.connect(self.select_image)
 
@@ -40,7 +42,7 @@ class LabelSettingsDialog(QtWidgets.QDialog):
         layout.addRow("Ширина этикетки (мм):", self.label_width)
         layout.addRow("Размер шрифта:", self.font_size)
         layout.addRow("Имя PDF-файла:", self.output_file)
-        layout.addRow("Изображение ухода (URL или путь):", care_layout)
+        layout.addRow("Изображение ухода (путь или URL):", care_layout)
 
         buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Save | QtWidgets.QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
@@ -61,5 +63,5 @@ class LabelSettingsDialog(QtWidgets.QDialog):
             "label_width_mm": self.label_width.value(),
             "font_size": self.font_size.value(),
             "output_file": self.output_file.text(),
-            "care_image_url": self.care_image_input.text()
+            "care_image_path": self.care_image_input.text()
         }

--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from db_dialog import DBConfigDialog
 from label_settings import LabelSettingsDialog
 
 class LabelMakerApp(QtWidgets.QMainWindow):
+    """Main application window for the label maker GUI."""
+
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Label Maker")
@@ -42,6 +44,10 @@ class LabelMakerApp(QtWidgets.QMainWindow):
         self.db_settings_btn = QtWidgets.QPushButton("⚙ Настройки БД")
         self.db_settings_btn.clicked.connect(self.show_db_config_dialog)
         left_layout.addWidget(self.db_settings_btn)
+
+        self.label_settings_btn = QtWidgets.QPushButton("🏷️ Настройки этикетки")
+        self.label_settings_btn.clicked.connect(self.show_label_settings_dialog)
+        left_layout.addWidget(self.label_settings_btn)
 
         self.generate_button = QtWidgets.QPushButton("📤 Сгенерировать PDF")
         self.generate_button.clicked.connect(self.generate_pdf)
@@ -152,6 +158,7 @@ class LabelMakerApp(QtWidgets.QMainWindow):
 
 
 def run_gui():
+    """Entry point to launch the graphical interface."""
     app = QtWidgets.QApplication(sys.argv)
     window = LabelMakerApp()
     window.show()

--- a/preview_engine.py
+++ b/preview_engine.py
@@ -22,7 +22,7 @@ def render_preview(skus, settings, db_config, single=True):
         return img_path  # Временный путь
 
 def generate_preview_pdf(pdf_path, sku, settings, db_config, generator_func=generate_labels_entry):
-    # Генерирует PDF с одной этикеткой
+    """Generate a one-label PDF and store it at ``pdf_path``."""
     generator_func([sku], settings, db_config)
     # Переименовываем файл, если необходимо
     output_file = settings.get("output_file", "labels.pdf")
@@ -30,5 +30,6 @@ def generate_preview_pdf(pdf_path, sku, settings, db_config, generator_func=gene
         os.replace(output_file, pdf_path)
 
 def convert_pdf_to_image(pdf_path):
+    """Convert the first page of a PDF to a PIL image."""
     images = convert_from_path(pdf_path, dpi=150)
     return images[0] if images else None

--- a/settings.json
+++ b/settings.json
@@ -4,5 +4,6 @@
   "label_width_mm": 40,
   "font_size": 6,
   "output_file": "labels.pdf",
-  "care_image_url": "https://mouni.by/tools/labels/%D0%A3%D1%85%D0%BE%D0%B4%20%D0%BE%D0%B1%D1%80%D0%B5%D0%B7%D0%B0%D0%BD%D0%BD%D1%8B%D0%B9.png"
+  "care_image_path": "care.png"
 }
+


### PR DESCRIPTION
## Summary
- support local care image paths via `CARE_IMAGE_PATH`
- allow editing label settings from the GUI
- document classes and methods
- store default care image path in `settings.json`

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68765949d398832da28a08126c968a72