### PR TITLE
Load PDF parameters from JSON

### DIFF
--- a/label_engine.py
+++ b/label_engine.py
@@ -32,6 +32,8 @@ output_file = "labels.pdf"
 CARE_IMAGE_PATH = "care.png"
 
 # === PDF НАСТРОЙКИ ===
+# Значения по умолчанию для размеров и отступов. Все параметры могут
+# быть переопределены через ``settings.json``. Единицы измерения - миллиметры.
 page_width, page_height = 120 * mm, 70 * mm
 label_width = 40 * mm
 font_size = 6
@@ -321,7 +323,7 @@ def generate_labels(products):
         care_img_extra = 2
 
         has_barcode = any(line[4] for line in final_lines)
-        bc_height = 6
+        bc_height = barcode_height / mm  # высота штрихкода в мм
         bc_extra = 2
 
         physically_used_mm = 0
@@ -383,8 +385,8 @@ def generate_labels(products):
 
 
             if is_price and has_barcode:
-            
-                barcode_height_mm = 14
+
+                barcode_height_mm = barcode_height / mm
                 left_right_padding_mm = 2  # отступы 2 мм слева и справа
                 
                 usable_width_mm = (label_width / mm) - 2 * left_right_padding_mm
@@ -434,15 +436,20 @@ def generate_labels_entry(skus, settings, db_config):
         Database connection parameters.
     """
     global page_width, page_height, label_width, font_size
+    global min_line_height, barcode_height, bottom_margin, top_margin
     global MIN_LINE_HEIGHT, MAX_LINE_HEIGHT, CARE_IMAGE_PATH, output_file
 
     page_width = settings.get("page_width_mm", 120) * mm
     page_height = settings.get("page_height_mm", 70) * mm
     label_width = settings.get("label_width_mm", 40) * mm
     font_size = settings.get("font_size", 6)
+    min_line_height = settings.get("min_line_height_mm", 2.0) * mm
+    barcode_height = settings.get("barcode_height_mm", 6) * mm
+    bottom_margin = settings.get("bottom_margin_mm", 0) * mm
+    top_margin = settings.get("top_margin_mm", 2) * mm
     output_file = settings.get("output_file", "labels.pdf")
     CARE_IMAGE_PATH = settings.get("care_image_path", "care.png")
-    MIN_LINE_HEIGHT = 2.0 * mm
+    MIN_LINE_HEIGHT = min_line_height
     MAX_LINE_HEIGHT = 4.0 * mm
 
     products = get_products_by_skus(skus, db_config)

--- a/label_settings.py
+++ b/label_settings.py
@@ -27,6 +27,23 @@ class LabelSettingsDialog(QtWidgets.QDialog):
         self.font_size.setMaximum(100)
         self.font_size.setValue(current_settings.get("font_size", 6))
 
+        self.min_line_height = QtWidgets.QDoubleSpinBox()
+        self.min_line_height.setDecimals(1)
+        self.min_line_height.setMaximum(100)
+        self.min_line_height.setValue(current_settings.get("min_line_height_mm", 2.0))
+
+        self.barcode_height = QtWidgets.QSpinBox()
+        self.barcode_height.setMaximum(100)
+        self.barcode_height.setValue(current_settings.get("barcode_height_mm", 6))
+
+        self.bottom_margin = QtWidgets.QSpinBox()
+        self.bottom_margin.setMaximum(100)
+        self.bottom_margin.setValue(current_settings.get("bottom_margin_mm", 0))
+
+        self.top_margin = QtWidgets.QSpinBox()
+        self.top_margin.setMaximum(100)
+        self.top_margin.setValue(current_settings.get("top_margin_mm", 2))
+
         self.output_file = QtWidgets.QLineEdit(current_settings.get("output_file", "labels.pdf"))
 
         self.care_image_input = QtWidgets.QLineEdit(current_settings.get("care_image_path", ""))
@@ -41,6 +58,10 @@ class LabelSettingsDialog(QtWidgets.QDialog):
         layout.addRow("Высота страницы (мм):", self.page_height)
         layout.addRow("Ширина этикетки (мм):", self.label_width)
         layout.addRow("Размер шрифта:", self.font_size)
+        layout.addRow("Мин. высота строки (мм):", self.min_line_height)
+        layout.addRow("Высота штрихкода (мм):", self.barcode_height)
+        layout.addRow("Отступ сверху (мм):", self.top_margin)
+        layout.addRow("Отступ снизу (мм):", self.bottom_margin)
         layout.addRow("Имя PDF-файла:", self.output_file)
         layout.addRow("Изображение ухода (путь или URL):", care_layout)
 
@@ -62,6 +83,10 @@ class LabelSettingsDialog(QtWidgets.QDialog):
             "page_height_mm": self.page_height.value(),
             "label_width_mm": self.label_width.value(),
             "font_size": self.font_size.value(),
+            "min_line_height_mm": self.min_line_height.value(),
+            "barcode_height_mm": self.barcode_height.value(),
+            "bottom_margin_mm": self.bottom_margin.value(),
+            "top_margin_mm": self.top_margin.value(),
             "output_file": self.output_file.text(),
             "care_image_path": self.care_image_input.text()
         }

--- a/settings.json
+++ b/settings.json
@@ -3,6 +3,10 @@
   "page_height_mm": 70,
   "label_width_mm": 40,
   "font_size": 6,
+  "min_line_height_mm": 2.0,
+  "barcode_height_mm": 6,
+  "bottom_margin_mm": 0,
+  "top_margin_mm": 2,
   "output_file": "labels.pdf",
   "care_image_path": "care.png"
 }


### PR DESCRIPTION
## Summary
- configure PDF layout params via `settings.json`
- expose margins, barcode height, min line height in settings dialog

## Testing
- `python -m py_compile config_loader.py db_dialog.py label_settings.py main.py preview_engine.py label_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68765b1f23cc832d928c2e5ae13ced59