### PR TITLE
Handle DB connection errors

### DIFF
--- a/label_engine.py
+++ b/label_engine.py
@@ -14,7 +14,7 @@ import json
 from reportlab.graphics.shapes import Drawing
 from reportlab.graphics.barcode import createBarcodeDrawing
 from reportlab.graphics import renderPDF
-from database_service import DatabaseService
+from database_service import DatabaseService, DatabaseConnectionError
 from pathlib import Path
 
 # === НАСТРОЙКИ ===
@@ -415,7 +415,11 @@ class LabelGenerator:
         Сервис БД передается через конструктор.
         """
         # Загружаем данные товаров из базы
-        products = self.db_service.get_products_by_skus(skus)
+        try:
+            products = self.db_service.get_products_by_skus(skus)
+        except DatabaseConnectionError as exc:
+            print(f"[DB ERROR] {exc}")
+            return
 
         # Расширяем список товаров с учётом количества
         expanded_products: list[dict] = []
@@ -431,5 +435,8 @@ def generate_labels_entry(skus, settings, db_config):
     """Высокоуровневая функция запуска генерации этикеток."""
     db_service = DatabaseService(db_config)
     generator = LabelGenerator(settings, db_service)
-    generator.generate_labels_entry(skus)
+    try:
+        generator.generate_labels_entry(skus)
+    except DatabaseConnectionError as exc:
+        print(f"[DB ERROR] {exc}")
 

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from config_loader import load_settings, load_db_config
 
 from preview_engine import generate_preview_pdf, convert_pdf_to_image
 from label_engine import generate_labels_entry
+from database_service import DatabaseConnectionError
 from db_dialog import DBConfigDialog
 from label_settings import LabelSettingsDialog
 
@@ -171,6 +172,8 @@ class LabelMakerApp(QtWidgets.QMainWindow):
                 image_qt = QtGui.QImage(image.tobytes("raw", "RGB"), image.width, image.height, QtGui.QImage.Format_RGB888)
                 pixmap = QtGui.QPixmap.fromImage(image_qt)
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), QtCore.Qt.KeepAspectRatio))
+        except DatabaseConnectionError as exc:
+            QtWidgets.QMessageBox.critical(self, "Ошибка БД", str(exc))
         except Exception as e:
             self.log_output.append(f"❌ Ошибка при превью: {e}")
 
@@ -187,6 +190,8 @@ class LabelMakerApp(QtWidgets.QMainWindow):
                 image_qt = QtGui.QImage(image.tobytes("raw", "RGB"), image.width, image.height, QtGui.QImage.Format_RGB888)
                 pixmap = QtGui.QPixmap.fromImage(image_qt)
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), QtCore.Qt.KeepAspectRatio))
+        except DatabaseConnectionError as exc:
+            QtWidgets.QMessageBox.critical(self, "Ошибка БД", str(exc))
         except Exception as e:
             self.log_output.append(f"❌ Ошибка при превью: {e}")
 
@@ -215,6 +220,8 @@ class LabelMakerApp(QtWidgets.QMainWindow):
             if sys.platform == "win32":
                 os.startfile(self.settings['output_file'])
 
+        except DatabaseConnectionError as exc:
+            QtWidgets.QMessageBox.critical(self, "Ошибка БД", str(exc))
         except Exception as e:
             self.log_output.append(f"❌ Ошибка генерации: {e}")
             QtWidgets.QMessageBox.critical(self, "Ошибка", f"Не удалось сгенерировать PDF:\n{str(e)}")

--- a/preview_engine.py
+++ b/preview_engine.py
@@ -1,4 +1,5 @@
 from label_engine import generate_labels_entry
+from database_service import DatabaseConnectionError
 import tempfile, os
 from pdf2image import convert_from_path
 
@@ -51,6 +52,8 @@ def generate_preview_pdf(pdf_path, skus, settings, db_config, generator_func=gen
 
     try:
         generator_func(sku_list, settings, db_config)
+    except DatabaseConnectionError as exc:
+        print(f"[DB ERROR] {exc}")
     finally:
         # Restore the original output_file setting if it existed.
         if original_output is not None:


### PR DESCRIPTION
## Summary
- add `DatabaseConnectionError` and wrap connection logic
- catch connection errors in label engine, preview engine and GUI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876a124a580832da077b2c3911fd0af