### PR TITLE
Add DB connection check utility

### DIFF
--- a/database_service.py
+++ b/database_service.py
@@ -40,6 +40,16 @@ class DatabaseService:
                 f"Не удалось подключиться к базе данных: {exc}"
             ) from exc
 
+    def check_connection(self) -> None:
+        """Verify that connection parameters are valid by opening a connection.
+
+        The method immediately closes the connection after opening it.  Any
+        errors raised during connection are rethrown as
+        :class:`DatabaseConnectionError`.
+        """
+        conn = self._connect()
+        conn.close()
+
     def get_term_labels(self, term_slugs: Iterable[str]) -> Dict[str, str]:
         """\
         Возвращает словарь ``slug -> название`` для переданных slug'ов.

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from config_loader import load_settings, load_db_config
 
 from preview_engine import generate_preview_pdf, convert_pdf_to_image
 from label_engine import generate_labels_entry
-from database_service import DatabaseConnectionError
+from database_service import DatabaseConnectionError, DatabaseService
 from db_dialog import DBConfigDialog
 from label_settings import LabelSettingsDialog
 
@@ -277,12 +277,14 @@ class LabelMakerApp(QtWidgets.QMainWindow):
         от результата попытки подключения.
         """
         try:
-            import mysql.connector
-            conn = mysql.connector.connect(**self.db_config)
-            conn.close()
+            service = DatabaseService(self.db_config)
+            service.check_connection()
             self.db_status_label.setText("🟢 Подключено к БД")
             self.db_status_label.setStyleSheet("color: green;")
-        except Exception as e:
+        except DatabaseConnectionError:
+            self.db_status_label.setText("🔴 Нет подключения к БД")
+            self.db_status_label.setStyleSheet("color: red;")
+        except Exception:
             self.db_status_label.setText("🔴 Нет подключения к БД")
             self.db_status_label.setStyleSheet("color: red;")
 


### PR DESCRIPTION
## Summary
- add a `check_connection` method to `DatabaseService`
- use `DatabaseService.check_connection` in GUI DB status updates
- clean up an unnecessary local `mysql.connector` import

## Testing
- `python3 -m py_compile main.py database_service.py label_engine.py db_dialog.py config_loader.py preview_engine.py label_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_6876a285e940832db1807d18e942b3cc