### PR TITLE
Use logging instead of prints

### DIFF
--- a/label_engine.py
+++ b/label_engine.py
@@ -16,6 +16,10 @@ from reportlab.graphics.barcode import createBarcodeDrawing
 from reportlab.graphics import renderPDF
 from database_service import DatabaseService, DatabaseConnectionError
 from pathlib import Path
+import logging
+
+# Логгер модуля используется для вывода предупреждений и ошибок.
+logger = logging.getLogger(__name__)
 
 # === НАСТРОЙКИ ===
 
@@ -402,7 +406,8 @@ class LabelGenerator:
             buffer.showPage()
 
         buffer.save()
-        print(f"Сгенерировано: {self.output_file}")
+        # Предупреждение о пути сгенерированного PDF-файла.
+        logger.warning("Сгенерировано: %s", self.output_file)
 
     def generate_labels_entry(self, skus: list[str]) -> None:
         """\
@@ -418,7 +423,8 @@ class LabelGenerator:
         try:
             products = self.db_service.get_products_by_skus(skus)
         except DatabaseConnectionError as exc:
-            print(f"[DB ERROR] {exc}")
+            # Ошибка подключения к БД отображается в логах.
+            logger.error("[DB ERROR] %s", exc)
             return
 
         # Расширяем список товаров с учётом количества
@@ -438,5 +444,6 @@ def generate_labels_entry(skus, settings, db_config):
     try:
         generator.generate_labels_entry(skus)
     except DatabaseConnectionError as exc:
-        print(f"[DB ERROR] {exc}")
+        # Логируем проблемы с подключением к БД при верхнеуровневом вызове.
+        logger.error("[DB ERROR] %s", exc)
 

--- a/preview_engine.py
+++ b/preview_engine.py
@@ -2,6 +2,10 @@ from label_engine import generate_labels_entry
 from database_service import DatabaseConnectionError
 import tempfile, os
 from pdf2image import convert_from_path
+import logging
+
+# Логгер модуля для вывода ошибок при генерации превью.
+logger = logging.getLogger(__name__)
 
 def render_preview(skus, settings, db_config, single=True):
     """
@@ -53,7 +57,8 @@ def generate_preview_pdf(pdf_path, skus, settings, db_config, generator_func=gen
     try:
         generator_func(sku_list, settings, db_config)
     except DatabaseConnectionError as exc:
-        print(f"[DB ERROR] {exc}")
+        # Выводим ошибку подключения к базе данных при формировании превью.
+        logger.error("[DB ERROR] %s", exc)
     finally:
         # Restore the original output_file setting if it existed.
         if original_output is not None:


### PR DESCRIPTION
## Summary
- add module loggers in `label_engine` and `preview_engine`
- log errors and warnings instead of printing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d78c72a0832dbd8d4c1561e32e88