### PR TITLE
Fix font path resolution

### DIFF
--- a/label_engine.py
+++ b/label_engine.py
@@ -44,8 +44,16 @@ DEFAULT_TOP_MARGIN_MM = 2
 DEFAULT_LABELS_PER_PAGE = 3
 
 # === РЕГИСТРАЦИЯ ШРИФТОВ ===
-pdfmetrics.registerFont(TTFont("DejaVuSans", "fonts/DejaVuSans.ttf"))
-pdfmetrics.registerFont(TTFont("DejaVuSans-Bold", "fonts/DejaVuSans-Bold.ttf"))
+# Полные пути к файлам шрифтов. Используем абсолютные пути, чтобы модуль
+# работал корректно вне зависимости от текущей рабочей директории.
+BASE_DIR = Path(__file__).resolve().parent
+FONT_DIR = BASE_DIR / "fonts"
+
+REGULAR_FONT_PATH = FONT_DIR / "DejaVuSans.ttf"
+BOLD_FONT_PATH = FONT_DIR / "DejaVuSans-Bold.ttf"
+
+pdfmetrics.registerFont(TTFont("DejaVuSans", str(REGULAR_FONT_PATH)))
+pdfmetrics.registerFont(TTFont("DejaVuSans-Bold", str(BOLD_FONT_PATH)))
 
 # === ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ ===
 def extract_composition(text):

--- a/tests/test_font_paths.py
+++ b/tests/test_font_paths.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import unittest
+import importlib
+import tempfile
+from pathlib import Path
+
+from reportlab.pdfbase import pdfmetrics
+
+
+class FontPathResolutionTests(unittest.TestCase):
+    """Ensure fonts are registered when module imported from any directory."""
+
+    def test_import_from_other_directory_registers_fonts(self):
+        # Путь к корню проекта с модулем label_engine
+        repo_root = Path(__file__).resolve().parent.parent
+        module_name = "label_engine"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prev_cwd = os.getcwd()
+            prev_path = sys.path.copy()
+            try:
+                os.chdir(tmpdir)
+                sys.path.insert(0, str(repo_root))
+                if module_name in sys.modules:
+                    del sys.modules[module_name]
+                importlib.invalidate_caches()
+                __import__(module_name)
+                self.assertIn("DejaVuSans", pdfmetrics.getRegisteredFontNames())
+                self.assertIn(
+                    "DejaVuSans-Bold", pdfmetrics.getRegisteredFontNames()
+                )
+            finally:
+                os.chdir(prev_cwd)
+                sys.path = prev_path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use absolute paths when registering fonts in `label_engine.py`
- test that module works when imported from another directory

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6876e0f135a8832d92abf25f6e705137