### PR TITLE
Handle DB preview errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,7 +210,10 @@ class LabelMakerApp(QtWidgets.QMainWindow):
                 pixmap = QtGui.QPixmap.fromImage(image_qt)
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), QtCore.Qt.KeepAspectRatio))
         except DatabaseConnectionError as exc:
+            # Пользователь получает всплывающее сообщение при проблеме
+            # с подключением к БД, также фиксируем её в логе.
             QtWidgets.QMessageBox.critical(self, "Ошибка БД", str(exc))
+            self.log_output.append(f"❌ Ошибка БД: {exc}")
         except Exception as e:
             self.log_output.append(f"❌ Ошибка при превью: {e}")
 
@@ -230,7 +233,9 @@ class LabelMakerApp(QtWidgets.QMainWindow):
                 pixmap = QtGui.QPixmap.fromImage(image_qt)
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), QtCore.Qt.KeepAspectRatio))
         except DatabaseConnectionError as exc:
+            # Показываем ошибку подключения и логируем её.
             QtWidgets.QMessageBox.critical(self, "Ошибка БД", str(exc))
+            self.log_output.append(f"❌ Ошибка БД: {exc}")
         except Exception as e:
             self.log_output.append(f"❌ Ошибка при превью: {e}")
 

--- a/preview_engine.py
+++ b/preview_engine.py
@@ -43,6 +43,12 @@ def generate_preview_pdf(pdf_path, skus, settings, db_config, generator_func=gen
     generator_func : Callable
         Function used to generate labels. Defaults to
         :func:`generate_labels_entry`.
+
+    Raises
+    ------
+    DatabaseConnectionError
+        Возникает, если не удаётся подключиться к БД при генерации
+        превью. Исключение повторно пробрасывается после логирования.
     """
 
     if isinstance(skus, str):
@@ -59,6 +65,7 @@ def generate_preview_pdf(pdf_path, skus, settings, db_config, generator_func=gen
     except DatabaseConnectionError as exc:
         # Выводим ошибку подключения к базе данных при формировании превью.
         logger.error("[DB ERROR] %s", exc)
+        raise
     finally:
         # Restore the original output_file setting if it existed.
         if original_output is not None:

--- a/tests/test_preview_engine.py
+++ b/tests/test_preview_engine.py
@@ -1,0 +1,67 @@
+import os
+import unittest
+from unittest.mock import patch
+
+# Ensure Qt works in headless mode
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtWidgets
+
+import preview_engine
+from preview_engine import generate_preview_pdf
+from database_service import DatabaseConnectionError
+import main
+
+
+class GeneratePreviewPdfTests(unittest.TestCase):
+    """Ensure DB errors are logged and re-raised when creating previews."""
+
+    def test_reraises_database_error(self):
+        def failing_generator(*args, **kwargs):
+            raise DatabaseConnectionError("boom")
+
+        with self.assertLogs("preview_engine", level="ERROR") as cm:
+            with self.assertRaises(DatabaseConnectionError):
+                generate_preview_pdf(
+                    "out.pdf",
+                    "SKU",
+                    {},
+                    {},
+                    generator_func=failing_generator,
+                )
+        self.assertTrue(any("DB ERROR" in msg for msg in cm.output))
+
+
+class PreviewErrorHandlingTests(unittest.TestCase):
+    """Check that GUI handlers show a message box on DB errors."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QtWidgets.QApplication([])
+
+    def _create_window(self):
+        with patch.object(main, "load_settings", return_value={}), patch.object(
+            main, "load_db_config", return_value={}), patch.object(
+            main.LabelMakerApp, "update_db_status", return_value=None
+        ):
+            return main.LabelMakerApp()
+
+    def test_show_label_preview_displays_message_box(self):
+        window = self._create_window()
+        with patch.object(
+            main, "generate_preview_pdf", side_effect=DatabaseConnectionError("fail")
+        ), patch.object(QtWidgets.QMessageBox, "critical") as mock_critical:
+            window.show_label_preview("A")
+            mock_critical.assert_called_once()
+
+    def test_show_page_preview_displays_message_box(self):
+        window = self._create_window()
+        with patch.object(
+            main, "generate_preview_pdf", side_effect=DatabaseConnectionError("fail")
+        ), patch.object(QtWidgets.QMessageBox, "critical") as mock_critical:
+            window.show_page_preview("A")
+            mock_critical.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bubble up `DatabaseConnectionError` from `generate_preview_pdf`
- show message box and log database errors when previewing labels
- add unit tests for preview error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779cf897bc832da5d15435894b66a2