### PR TITLE
Add connection pooling and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ python install_dependencies.py
 The application settings are stored in `settings.json` and database
 configuration in `db_config.json`.
 
+### Database configuration
+
+Create a `db_config.json` file based on `db_config.example.json` with your
+connection details. Optional keys allow tuning connection behaviour:
+
+* `persistent` – keep a single connection open between queries.
+* `pool_size` – size of the MySQL connection pool (if > 0).
+* `max_retries` – how many times to retry connecting on transient errors.
+
 ## Running
 
 Execute the GUI with:

--- a/db_config.example.json
+++ b/db_config.example.json
@@ -1,0 +1,10 @@
+{
+  "host": "localhost",
+  "port": 3306,
+  "user": "user",
+  "password": "pass",
+  "database": "mydb",
+  "persistent": true,
+  "pool_size": 0,
+  "max_retries": 3
+}


### PR DESCRIPTION
## Summary
- add support for persistent or pooled DB connections
- retry connecting on transient errors
- document database config options
- provide example `db_config` file
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a799eab8832db900ffa822f95ea2