### PR TITLE
Improve DB connection logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -319,12 +319,14 @@ class LabelMakerApp(QtWidgets.QMainWindow):
         логируются, что упрощает диагностику проблем.
         """
         try:
+            logger.debug("Initializing DatabaseService for status check")
             service = DatabaseService(self.db_config)
             service.check_connection()
             self.db_status_label.setText("🟢 Подключено к БД")
             self.db_status_label.setStyleSheet("color: green;")
             return True
         except DatabaseConnectionError:
+            logger.error("Database connection failed")
             self.db_status_label.setText("🔴 Нет подключения к БД")
             self.db_status_label.setStyleSheet("color: red;")
             return False


### PR DESCRIPTION
## Summary
- add granular debug logs for all DB connection steps
- log database service status checks in the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687802e44c48832d821a33b7e8c47953